### PR TITLE
fix: 修复音乐馆互斥问题

### DIFF
--- a/layout/includes/page/music.pug
+++ b/layout/includes/page/music.pug
@@ -1,9 +1,9 @@
 if theme.music.enable
     #Music-bg
     #Music-page
-        meting-js(id=theme.music.id, server=theme.music.server, type=theme.music.type, mutex=theme.music.mutex, volume=theme.music.volume, preload="none", data-lrctype="0", order="random")
+        meting-js(id=theme.music.id server=theme.music.server type=theme.music.type mutex=theme.music.mutex ? "true" : "false" volume=theme.music.volume preload="none" data-lrctype="0" order="random")
     .Music-loading
-        div APlayer加载中...'
+        div APlayer加载中...
     script(pjax).
         (async function () {
             if (typeof initializeMusicPlayer === "undefined") await utils.getScript('!{url_for(theme.cdn.music_js)}').then(() => initializeMusicPlayer())


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/valor-x/hexo-theme-solitude/blob/main/CONTRIBUTING.md
-->

### 🔗 链接 issue

<!-- 请确保存在未解决的问题，将编号提及为 #123（示例） -->

### ❓ 修改类型

<!--代码引入了哪些类型的更改？在所有适用的框中放置一个“x”。 -->

- [x] 🐞 Bug fix (修复问题的连续性改)
- [ ] 👌 增强功能（改进现有功能，如性能）
- [ ] ✨ Feature（添加功能的连续性修改）
- [ ] ⚠️ 中断修改（重大的修改，如配置文件调整、模块移除）

### 📚 描述

<!-- 详细说明你的更改 -->
<!-- 为什么需要此更改？它解决了什么问题？-->
<!-- 如果它解决了未解决的问题，请在此处链接到该问题。例如，“Resolves #1337” -->

在启用音乐胶囊时，进入音乐馆页面播放音乐两个播放器同时播放的问题进行修复

### 📝 清单

<!-- 在所有适用的框中放置一个“x”。 -->
<!-- 如果更改需要文档 PR，请适当地链接它 -->
<!-- 如果不确定其中任何一个，请随时询问。我们是来帮忙的！ -->

- [ ] 我已链接问题或讨论。
- [x] 我已经添加了测试（如果可能的话）。
- [ ] 我已相应地更新了[文档](https://github.com/efuo/theme-solitude-docs)。
