### PR TITLE
缩小footer位置copywrite间距，并调整了randomlink的包含逻辑

### DIFF
--- a/layout/includes/inject/body.pug
+++ b/layout/includes/inject/body.pug
@@ -102,8 +102,8 @@ div
                 script(defer pjax src=url_for(theme.cdn.busuanzi_qj_js))
 
 
-if theme.footer.randomlink
-    include ../widgets/randomlink.pug
+//- if theme.footer.randomlink
+include ../widgets/randomlink.pug
 
 // newest comment
 include ../widgets/third-party/news-comment/newest-comment.pug

--- a/source/css/_layout/footer.styl
+++ b/source/css/_layout/footer.styl
@@ -197,6 +197,10 @@
         padding 0 8px
         margin 0 4px
 
+        .footer-bar-link
+          padding 8px 2px
+          margin 0
+
     .footer-bar-link
       margin 0 4px
       color var(--efu-fontcolor)


### PR DESCRIPTION
## 缩小footer位置copywrite间距
原有的间距过大，不太美观。下面为调整前后的间距：
![image](https://github.com/valor-x/hexo-theme-solitude/assets/52946026/06d467e4-797d-455c-86b6-719866b1bd60)
![image](https://github.com/valor-x/hexo-theme-solitude/assets/52946026/11beb423-9c41-4a89-a199-281fa89eaea5)

## 调整了randomlink的包含逻辑
可以实现在footer中的随机链接没开启的情况下使用javascript:travelling()函数