### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/everfu/hexo-theme-solitude/security/code-scanning/18](https://github.com/everfu/hexo-theme-solitude/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow involves publishing an npm package, it likely only needs `contents: read` to access the repository's contents. Additional permissions can be added if necessary, but we will start with the minimal required permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
