### PR TITLE
fix: 修复备案图标未设置时显示图片404

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -105,7 +105,8 @@ mixin beianInfo()
           title: item.name
         })
           +conditionalWrapper(item.icon)
-            img.beian-icon(src=url_for(item.icon), alt=item.name)
+            if item.icon
+              img.beian-icon(src=url_for(item.icon), alt=item.name)
           span.beian-name= item.name
     
     +link(_p('hexo'), _p('framework_by') + 'Hexo', { class: 'footer-bar-link' })


### PR DESCRIPTION
`conditionalWrapper()`无论如何都会执行block里的内容，而在备案处的block内部直接是一个img，导致无论字段是否有参数都会渲染，导致显示404