### PR TITLE
fix: 修复启用多个评论系统时无法正常显示

### DIFF
--- a/scripts/filter/comment.js
+++ b/scripts/filter/comment.js
@@ -9,5 +9,5 @@ hexo.extend.filter.register('before_generate', () => {
     if (typeof use === 'string') {
         use = use.split(',').slice(0,2)
     }
-    themeConfig.comment.use = use.map(item => item.toLowerCase().replace(/\b[a-z]/g, s => s.toUpperCase()))
+    themeConfig.comment.use = use.map(item => item.trim().toLowerCase().replace(/\b[a-z]/g, s => s.toUpperCase()))
 })


### PR DESCRIPTION
我注意到comment.js分割不同评论时使用的是split(',')，因此如果在config的评论块中这样使用“use: twikoo, giscus”会导致问题
虽然示例中有说明不能加空格“（例如： waline or waline,twikoo）”
但是use后面的可用评论系统示例确是带空格的“# waline, twikoo, valine, artalk, giscus”
同时文档也没对此有其余的说明，这很容易让人感到疑惑
所以我添加了在分割完后.trim()的逻辑以确保加了空格后也能正常获取
这样能避免一些让人疑惑的情况，且目前可用的评论系统并无名称带空格的