### PR TITLE
fix(aside): resolve sidebar configuration bug overriding aside: false

### DIFF
--- a/scripts/filter/default.js
+++ b/scripts/filter/default.js
@@ -14,7 +14,7 @@ hexo.extend.filter.register("after_post_render", function (data) {
     data.excerpt =
       layout === "post" ? data.description || data.excerpt : data.title;
     data.toc = !!(config.aside.toc[layout] && data.toc !== false);
-    data.aside = layout === "post" ? data.aside || true : data.aside || false;
+    data.aside = data.aside !== undefined ? data.aside : (layout === "post");
   };
 
   if (data.layout === "post" || data.layout === "page") {


### PR DESCRIPTION
Fixes an issue where setting `aside: false` in front-matter did not work for posts because the logical OR assignment overrode `false` with the default `true`. Refactored `scripts/filter/default.js` to strictly check for `undefined` instead of falsy values when applying layout defaults.

---
*PR created automatically by Jules for task [15767566367911098354](https://jules.google.com/task/15767566367911098354) started by @everfu*